### PR TITLE
feat: implement protected routes with AuthGuard and GuestGuard

### DIFF
--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,10 @@
+import { cn } from "@/lib/utils"
+import { Loader2Icon } from "lucide-react"
+
+function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+  return (
+    <Loader2Icon role="status" aria-label="Loading" className={cn("size-4 animate-spin", className)} {...props} />
+  )
+}
+
+export { Spinner }

--- a/src/features/auth/auth.hook.ts
+++ b/src/features/auth/auth.hook.ts
@@ -1,6 +1,6 @@
 import { useMutation } from "@tanstack/react-query"
 import { authService } from "./auth.service"
-import { useNavigate } from "react-router"
+import { useLocation, useNavigate } from "react-router"
 import { toast } from "sonner"
 import type { LoginPayload, RegisterPayload } from "./auth.schema"
 import { useAuthStore } from "./auth.store"
@@ -32,6 +32,12 @@ export const useLogin = () => {
 
     const setAuth = useAuthStore((state) => state.setAuth);
     const navigate = useNavigate();
+    const location = useLocation();
+    const fromLocation = (location.state as { from?: Location })?.from;
+
+    const from = fromLocation
+        ? `${fromLocation.pathname}${fromLocation.search}${fromLocation.hash}`
+        : "/";
 
     return useMutation({
 
@@ -42,7 +48,7 @@ export const useLogin = () => {
             const { token, username, name } = response.data;
 
             setAuth(token, { username, name });
-            navigate("/")
+            navigate(from, { replace: true });
         },
 
         onError: (error) => {

--- a/src/features/auth/auth.store.ts
+++ b/src/features/auth/auth.store.ts
@@ -7,11 +7,16 @@ export const useAuthStore = create<AuthState>()(
         (set) => ({
             token: null,
             user: null,
+            hasHydrated: false,
             setAuth: (token, user) => set({ token, user }),
             clearAuth: () => set({ token: null, user: null }),
+            setHasHydrated: (value) => set({ hasHydrated: value }),
         }),
         {
-            name: "auth-storage"
+            name: "auth-storage",
+            onRehydrateStorage: () => (state) => {
+                state?.setHasHydrated(true);
+            },
         }
     )
 )

--- a/src/features/auth/auth.types.ts
+++ b/src/features/auth/auth.types.ts
@@ -15,6 +15,8 @@ export interface UpdateUserPayload {
 export interface AuthState {
     token: string | null;
     user: User | null;
+    hasHydrated: boolean;
     setAuth: (token: string, user: User) => void;
     clearAuth: () => void;
+    setHasHydrated: (value: boolean) => void;
 }

--- a/src/features/auth/guards/AuthGuard.tsx
+++ b/src/features/auth/guards/AuthGuard.tsx
@@ -1,0 +1,22 @@
+import { Navigate, Outlet, useLocation } from "react-router";
+import { useAuthStore } from "../auth.store";
+import { Spinner } from "@/components/ui/spinner";
+
+export const AuthGuard = () => {
+
+    const token = useAuthStore((state) => state.token);
+    const hasHydrated = useAuthStore((state) => state.hasHydrated);
+    const location = useLocation();
+
+    if (!hasHydrated) {
+        return (
+            <div className="flex items-center gap-6">
+                <Spinner className="size-8" />
+            </div>
+        )
+    }
+
+    if (!token) return <Navigate to="/auth/login" replace state={{ from: location }} />
+
+    return <Outlet />
+};

--- a/src/features/auth/guards/GuestGuard.tsx
+++ b/src/features/auth/guards/GuestGuard.tsx
@@ -1,0 +1,21 @@
+import { Navigate, Outlet } from "react-router";
+import { useAuthStore } from "../auth.store";
+import { Spinner } from "@/components/ui/spinner";
+
+export const GuestGuard = () => {
+
+    const token = useAuthStore((state) => state.token);
+    const hasHydrated = useAuthStore((state) => state.hasHydrated);
+
+    if (!hasHydrated) {
+        return (
+            <div className="flex items-center gap-6">
+                <Spinner className="size-8" />
+            </div>
+        )
+    }
+
+    if (token) return <Navigate to="/" replace />
+
+    return <Outlet />
+};

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -5,30 +5,41 @@ import { createBrowserRouter } from "react-router";
 import RegisterPage from "@/pages/RegisterPage";
 import ContactPage from "@/pages/ContactPage";
 import LoginPage from "@/pages/LoginPage";
+import { AuthGuard } from "@/features/auth/guards/AuthGuard";
+import { GuestGuard } from "@/features/auth/guards/GuestGuard";
 
 export const router = createBrowserRouter([
     {
-        path: "auth",
-        Component: AuthLayout,
+        Component: GuestGuard,
         children: [
             {
-                path: "register",
-                Component: RegisterPage,
-            },
-            {
-                path: "login",
-                Component: LoginPage
+                path: "auth",
+                Component: AuthLayout,
+                children: [
+                    {
+                        path: "register",
+                        Component: RegisterPage,
+                    },
+                    {
+                        path: "login",
+                        Component: LoginPage
+                    }
+                ]
             }
-        ],
+        ]
     },
     {
-        path: "/",
-        Component: MainLayout,
+        Component: AuthGuard,
         children: [
             {
-                index: true,
-                Component: ContactPage,
-            },
-        ],
+                Component: MainLayout,
+                children: [
+                    {
+                        path: "/",
+                        Component: ContactPage,
+                    }
+                ]
+            }
+        ]
     },
 ])


### PR DESCRIPTION
- Add AuthGuard to redirect unauthenticated users to /auth/login with state.from for post-login redirect
- Add GuestGuard to redirect authenticated users away from auth pages to /
- Add hasHydrated state to auth store via onRehydrateStorage to prevent flash redirect on refresh
- Update useLogin to restore full URL (pathname + search + hash) after login
- Integrate guards into router wrapping MainLayout and AuthLayout respectively