### PR TITLE
feat: implement logout with API revocation and session clear

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -55,4 +55,5 @@ function Button({
   )
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export { Button, buttonVariants }

--- a/src/features/auth/auth.hook.ts
+++ b/src/features/auth/auth.hook.ts
@@ -17,7 +17,6 @@ export const useRegister = () => {
         onSuccess: () => {
 
             toast.success("Registrasi berhasil! Silahkan login");
-
             navigate("/auth/login");
         },
 
@@ -55,5 +54,27 @@ export const useLogin = () => {
 
             errorHookResponse(error);
         },
+    })
+}
+
+export const useLogout = () => {
+    const clearAuth = useAuthStore((state) => state.clearAuth);
+    const navigate = useNavigate();
+
+    return useMutation({
+
+        mutationFn: () => authService.logout(),
+
+        onSuccess: () => {
+
+            toast.success("Berhasil logout");
+            clearAuth();
+            navigate("/auth/login", { replace: true });
+        },
+
+        onError: (error) => {
+
+            errorHookResponse(error);
+        }
     })
 }

--- a/src/features/auth/auth.service.ts
+++ b/src/features/auth/auth.service.ts
@@ -17,5 +17,12 @@ export const authService = {
         const response = await api.post("/api/users/login", payload);
 
         return response.data;
+    },
+
+    logout: async (): Promise<ApiResponse<string>> => {
+
+        const response = await api.delete("/api/users/current");
+
+        return response.data;
     }
 } 

--- a/src/features/auth/auth.types.ts
+++ b/src/features/auth/auth.types.ts
@@ -7,11 +7,6 @@ export interface LoginResponseData extends User {
     token: string;
 }
 
-export interface UpdateUserPayload {
-    name?: string;
-    password?: string;
-}
-
 export interface AuthState {
     token: string | null;
     user: User | null;

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,9 +1,21 @@
+import { ButtonField } from "@/components/form/ButtonField";
+import { useLogout } from "@/features/auth/auth.hook";
 import { Outlet } from "react-router";
 
 export const MainLayout = () => {
+
+    const { mutate, isPending } = useLogout()
+
     return (
         <>
             <h1>MainLayout</h1>
+            <ButtonField
+                orientation="horizontal"
+                isPending={isPending}
+                label="Logout"
+                onClick={() => mutate()}
+                className="cursor-pointer"
+            />
             <main>
                 <Outlet />
             </main>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -23,7 +23,7 @@ api.interceptors.request.use((config) => {
 })
 
 api.interceptors.response.use((response) => {
-
+    
     return response;
 }, (error: AxiosError) => {
 

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+        "incremental": true,
         "target": "ES2023",
         "useDefineForClassFields": true,
         "lib": ["ES2023", "DOM", "DOM.Iterable"],


### PR DESCRIPTION
- Add authService.logout() hitting DELETE /api/users/current
- Add useLogout hook using useMutation with toast, clearAuth, and navigate on success
- Add logout button to MainLayout
- Fix axios interceptor to only redirect on 401 when token exists
- Add incremental flag to tsconfig.app.json to pair with tsBuildInfoFile