### PR TITLE
feat: add dashboard routing and auth sheet focus (ISSUE-17)

### DIFF
--- a/docs/issues/ISSUE-17-routing-dashboard.md
+++ b/docs/issues/ISSUE-17-routing-dashboard.md
@@ -1,0 +1,72 @@
+# Issue #17 — Update routing struktur: `/dashboard` dan `/dashboard/profile`
+
+| Meta | Detail |
+|------|--------|
+| **Status** | OPEN |
+| **Labels** | `refactor`, `routing` |
+| **Dibuat** | 2026-03-30 |
+| **Ditutup** | — |
+
+## Context
+
+Saat ini halaman utama setelah login menggunakan route `/` (root). Seiring aplikasi berkembang (dashboard, profile, dsb.), diperlukan struktur routing yang lebih eksplisit dan scalable.
+
+Perubahan yang diperlukan:
+- **`/`** → redirect ke `/dashboard`
+- **`/dashboard`** → halaman utama (ContactPage / halaman kontak)
+- **`/dashboard/profile`** → halaman profile user
+
+Hal ini membuat hierarki route lebih jelas dan mempersiapkan fondasi untuk penambahan halaman baru di bawah prefix `/dashboard`.
+
+## Goals
+
+- Pindahkan route `/` menjadi `/dashboard` di `routes/index.tsx`.
+- Tambahkan redirect dari `/` ke `/dashboard` (opsional tapi UX-friendly).
+- Siapkan slot route `/dashboard/profile` (boleh placeholder dulu, akan diisi di Issue #19).
+- Pastikan guard `AuthGuard` dan `GuestGuard` tetap berjalan dengan benar setelah perubahan.
+
+## Scope of Work
+
+**In scope**
+
+- `src/routes/index.tsx`: update path `"/"` menjadi `"dashboard"`, tambah anak route `"profile"` (placeholder).
+- Redirect `/` → `/dashboard` menggunakan `<Navigate>` dari react-router.
+- Update `navigate` di `auth.hook.ts` (`useLogin`) agar `from` default mengarah ke `/dashboard`.
+
+**Out of scope**
+
+- Implementasi UI halaman profile (Issue #19).
+- Perubahan guard logic.
+
+## Suggested Technical Checklist
+
+- [ ] Update `routes/index.tsx`:
+  - Ganti `path: "/"` menjadi `path: "dashboard"` di dalam `MainLayout` children.
+  - Tambah route `{ path: "profile", Component: ProfilePage }` sebagai anak `/dashboard` (bisa placeholder dulu).
+  - Tambah fallback route `{ path: "/", element: <Navigate to="/dashboard" replace /> }`.
+- [ ] Update default `from` di `useLogin` di `auth.hook.ts` menjadi `/dashboard`.
+- [ ] Verifikasi guard redirect masih ke path yang benar setelah login/logout.
+- [ ] Smoke test semua route (login → `/dashboard`, logout → `/auth/login`, akses langsung `/` → redirect ke `/dashboard`).
+
+## Acceptance Criteria
+
+- Setelah login, user diarahkan ke `/dashboard`.
+- Akses langsung ke `/` secara otomatis redirect ke `/dashboard`.
+- Route `/dashboard/profile` tersedia (meskipun kontennya placeholder).
+- Tidak ada regresi pada alur login, logout, dan guard.
+- Tidak ada broken link / blank screen.
+
+## Blackbox Test Plan
+
+| # | Skenario | Langkah | Ekspektasi |
+|---|----------|---------|------------|
+| 1 | Login sukses | Login dengan kredensial valid | Redirect ke `/dashboard`, bukan `/` |
+| 2 | Akses root | Buka `/` saat sudah login | Redirect otomatis ke `/dashboard` |
+| 3 | Akses root tanpa login | Buka `/` tanpa login | Redirect ke `/auth/login` |
+| 4 | Akses profil | Buka `/dashboard/profile` saat sudah login | Halaman profile tampil (atau placeholder) |
+| 5 | Logout | Klik logout | Redirect ke `/auth/login` |
+
+## Notes
+
+- Issue ini adalah **prasyarat** untuk Issue #19 (Profile Page) dan Issue #20 (Profile Dropdown Navbar).
+- Pastikan `useLogin` hook juga diupdate agar `from` default menjadi `/dashboard` sehingga flow redirect setelah login konsisten.

--- a/docs/issues/ISSUE-19-feature-user-profile.md
+++ b/docs/issues/ISSUE-19-feature-user-profile.md
@@ -1,0 +1,137 @@
+# Issue #19 — Feature User Profile: `user.service`, `user.hook`, schema, dan halaman Profile
+
+| Meta | Detail |
+|------|--------|
+| **Status** | OPEN |
+| **Labels** | `feature`, `ui`, `api-integration` |
+| **Dibuat** | 2026-03-30 |
+| **Ditutup** | — |
+| **Depends on** | Issue #17 (routing `/dashboard/profile`) |
+
+## Context
+
+Aplikasi perlu menyediakan halaman profile user yang memungkinkan user melihat dan memperbarui data dirinya. API yang digunakan:
+
+- **`GET /api/users/current`** — Fetch data user yang sedang login.
+- **`PATCH /api/users/current`** — Update name dan/atau password user.
+
+Kedua endpoint ini memerlukan header `Authorization: Bearer <token>` yang sudah dihandle oleh Axios interceptor di `lib/api.ts`.
+
+Mengikuti pola arsitektur yang sudah ada (`features/auth/`), fitur ini dipisahkan ke folder `features/user/`.
+
+## Goals
+
+- Buat feature folder `src/features/user/` dengan service, hook, schema, dan types.
+- Implementasi `GET /api/users/current` untuk menampilkan data profil di form.
+- Implementasi `PATCH /api/users/current` untuk submit perubahan name dan/atau password.
+- Buat halaman `ProfilePage` di `/dashboard/profile` dengan form update profil.
+- Setelah update sukses, sync `name` di `useAuthStore` agar navbar langsung reflect perubahan.
+- Password pada form update bersifat **opsional** (tidak wajib diisi).
+
+## API Reference
+
+### GET /api/users/current
+```
+Response 200:
+{
+  "success": true,
+  "data": { "username": "cah_ganteng", "name": "Muhammad Malfin" }
+}
+```
+
+### PATCH /api/users/current
+```
+Request Body (semua field opsional, minimal salah satu harus ada):
+{ "name": "Budi Sudarsono", "password": "rahasia123" }
+
+Response 200:
+{
+  "success": true,
+  "data": { "username": "cah_ganteng", "name": "Budi Sudarsono" }
+}
+```
+
+## Scope of Work
+
+**Struktur file yang dibuat/dimodifikasi:**
+
+```
+src/features/user/
+├── user.types.ts       # Type UpdateUserPayload, dll
+├── user.schema.ts      # Zod schema untuk form update (name opsional, password opsional)
+├── user.service.ts     # getProfile(), updateProfile()
+└── user.hook.ts        # useGetProfile(), useUpdateProfile()
+
+src/pages/
+└── ProfilePage.tsx     # Halaman profile dengan form update
+
+src/features/auth/
+└── auth.store.ts       # Update setAuth / tambah action updateUser untuk sync name
+```
+
+**Out of scope**
+
+- Upload foto profil / avatar.
+- Perubahan username (tidak didukung API).
+- Validasi server-side selain error response handling.
+
+## Suggested Technical Checklist
+
+### `user.types.ts`
+- [ ] Definisikan type `UpdateUserPayload { name?: string; password?: string }`.
+
+### `user.schema.ts`
+- [ ] Buat Zod schema `updateUserSchema`:
+  - `name`: string, min 1 karakter, **opsional** (`.optional()` atau empty string allowed).
+  - `password`: string, min 8 karakter, **opsional**.
+  - Tambah `.refine()` agar minimal salah satu field harus diisi.
+- [ ] Export `UpdateUserValues` type dari schema.
+
+### `user.service.ts`
+- [ ] `getProfile()`: `GET /api/users/current` → return `ApiResponse<User>`.
+- [ ] `updateProfile(payload)`: `PATCH /api/users/current` → return `ApiResponse<User>`.
+
+### `user.hook.ts`
+- [ ] `useGetProfile()`: `useQuery` dengan `queryKey: ['profile']`.
+- [ ] `useUpdateProfile()`: `useMutation`:
+  - `onSuccess`: toast sukses + update `name` di `useAuthStore` (via `setAuth` atau action baru) + `invalidateQueries(['profile'])`.
+  - `onError`: gunakan `errorHookResponse(error)`.
+
+### `auth.store.ts`
+- [ ] Tambah action `updateUser(user: Partial<User>)` untuk update `name` di store tanpa clear token.
+
+### `ProfilePage.tsx`
+- [ ] Fetch data profil via `useGetProfile()` dan pre-fill form.
+- [ ] Form field: **Name** (text), **Password baru** (password — opsional), **Konfirmasi Password** (opsional, harus match).
+- [ ] Field **Username** ditampilkan sebagai readonly/disabled (tidak bisa diubah).
+- [ ] Submit via `useUpdateProfile()`, kirim hanya field yang terisi.
+- [ ] Loading state saat fetch dan submit.
+- [ ] Error handling pada form (pesan di bawah field via `react-hook-form` + `zodResolver`).
+- [ ] Styling: mengikuti design system proyek (shadcn components: `Card`, `Input`, `Button`, `Label`).
+
+## Acceptance Criteria
+
+- Halaman `/dashboard/profile` menampilkan data user yang sedang login (username readonly, name terisi otomatis dari API).
+- User dapat mengubah name dan/atau password.
+- Password bersifat opsional — form valid meski field password kosong (asalkan name diisi minimal 1 karakter, atau sebaliknya).
+- Setelah update sukses, name di navbar/dropdown langsung berubah tanpa re-login.
+- Error dari API (400, 401) ditampilkan via toast.
+- Loading spinner/disabled state aktif saat fetching dan submitting.
+
+## Blackbox Test Plan
+
+| # | Skenario | Langkah | Ekspektasi |
+|---|----------|---------|------------|
+| 1 | Tampil data profil | Buka `/dashboard/profile` | Form pre-filled dengan `name` dari API; `username` readonly |
+| 2 | Update name saja | Ubah name, kosongkan password, submit | Sukses; name di navbar berubah; toast muncul |
+| 3 | Update password saja | Kosongkan name, isi password baru (≥8 char), submit | Sukses; toast muncul |
+| 4 | Update keduanya | Isi name baru + password baru, submit | Sukses; name di navbar berubah |
+| 5 | Form kosong semua | Tidak mengubah apapun, klik submit | Validasi gagal — setidaknya 1 field harus diisi |
+| 6 | Password terlalu pendek | Isi password < 8 karakter, submit | Error validasi Zod muncul di bawah field |
+| 7 | Error API | Simulasi 401 (token expired) | Toast error muncul |
+
+## Notes
+
+- Validasi password konfirmasi (`confirmPassword`) cukup di sisi frontend via Zod `.refine()` — tidak dikirim ke API.
+- Gunakan `react-hook-form` + `@hookform/resolvers/zod` sesuai pola yang sudah ada di `auth.schema.ts`.
+- Untuk men-sync store setelah update, pertimbangkan `setAuth(token, updatedUser)` dengan token yang sudah ada, atau tambah action `updateUser` yang hanya update field `user` di store.

--- a/docs/issues/ISSUE-21-profile-dropdown-navbar.md
+++ b/docs/issues/ISSUE-21-profile-dropdown-navbar.md
@@ -1,0 +1,88 @@
+# Issue #21 — Profile Dropdown di Navbar (Ganti Logout Button)
+
+| Meta | Detail |
+|------|--------|
+| **Status** | OPEN |
+| **Labels** | `feature`, `ui`, `navbar` |
+| **Dibuat** | 2026-03-30 |
+| **Ditutup** | — |
+| **Depends on** | Issue #17 (routing), Issue #19 (ProfilePage tersedia) |
+
+## Context
+
+Saat ini `MainLayout.tsx` memiliki Logout button yang langsung tampil di navbar. Seiring ditambahkannya halaman profile, diperlukan **dropdown menu** pada navbar untuk mengelompokkan aksi terkait user (profil, logout) agar lebih rapi dan scalable.
+
+Dropdown ini akan menampilkan:
+1. **Header dropdown** — nama user yang sedang login (dari `useAuthStore`).
+2. **Menu item "Profile"** — navigate ke `/dashboard/profile`.
+3. **Menu item "Logout"** — memicu logout (pindah dari button langsung ke dalam dropdown).
+
+## Goals
+
+- Hapus Logout button yang berdiri sendiri dari navbar `MainLayout`.
+- Tambah komponen `ProfileDropdown` (atau gunakan shadcn `DropdownMenu`) di posisi yang sama.
+- Tampilkan nama user aktif di bagian atas dropdown.
+- Sediakan link ke `/dashboard/profile` dan aksi logout di dalam dropdown.
+
+## Scope of Work
+
+**File yang diubah/dibuat:**
+
+```
+src/layouts/MainLayout.tsx         # Integrasi ProfileDropdown, hapus Logout button lama
+src/components/ProfileDropdown.tsx # Komponen baru (opsional, bisa inline di MainLayout)
+```
+
+**Out of scope**
+
+- Avatar / foto profil user di dropdown.
+- Notifikasi atau badge di icon.
+
+## Suggested Technical Checklist
+
+### Komponen `ProfileDropdown`
+- [ ] Install / pastikan `DropdownMenu` dari shadcn tersedia (`@/components/ui/dropdown-menu`).
+- [ ] Trigger: icon user (`UserCircle` atau `CircleUser` dari lucide-react) + nama user (opsional tampil di samping icon, bisa hidden di mobile).
+- [ ] Dropdown content:
+  - **Header** (non-clickable): tampilkan `user.name` dari `useAuthStore` — gunakan class yang membedakan secara visual (font-weight, muted color, border-bottom).
+  - **Item "Profile"**: `<Link to="/dashboard/profile">` atau navigate programmatically → icon `User` + label "Profile".
+  - **Separator** (`<DropdownMenuSeparator />`).
+  - **Item "Logout"**: icon `LogOut` + label "Logout" — onClick trigger `mutate()` dari `useLogout()`, disabled saat `isPending`.
+- [ ] Loading state saat logout: item "Logout" disabled + spinner icon.
+
+### `MainLayout.tsx`
+- [ ] Hapus `<Button>` Logout yang lama.
+- [ ] Tambah `<ProfileDropdown />` di nav (posisi kanan, setelah `ThemeToggle`).
+
+### Responsivitas
+- [ ] Dropdown trigger cukup terlihat di mobile (icon saja sudah cukup, nama bisa hidden di `sm:` ke bawah).
+- [ ] Dropdown panel tidak overflow di layar sempit.
+
+## Acceptance Criteria
+
+- Logout button lama tidak lagi tampil di navbar.
+- Ada icon/trigger di navbar kanan yang membuka dropdown saat diklik.
+- Bagian atas dropdown menampilkan nama user yang sedang login.
+- Klik "Profile" navigasi ke `/dashboard/profile`.
+- Klik "Logout" menjalankan logout + redirect ke `/auth/login`.
+- Saat logout sedang berjalan, item "Logout" disabled dan ada indikator loading.
+- Tampil rapi di mobile (375px) dan desktop (1280px+).
+
+## Blackbox Test Plan
+
+| # | Skenario | Langkah | Ekspektasi |
+|---|----------|---------|------------|
+| 1 | Buka dropdown | Klik icon user di navbar | Dropdown terbuka dengan nama user di atas |
+| 2 | Nama user benar | Lihat header dropdown | Nama sesuai data login yang ada di store |
+| 3 | Link profil | Klik "Profile" di dropdown | Navigasi ke `/dashboard/profile` |
+| 4 | Logout | Klik "Logout" di dropdown | Redirect ke `/auth/login`, store cleared |
+| 5 | Loading logout | Klik logout, amati sebelum redirect | Item disabled, spinner tampil |
+| 6 | Tutup dropdown | Klik di luar dropdown | Dropdown tertutup |
+| 7 | Mobile | Buka di viewport 375px | Trigger terlihat; dropdown tidak overflow |
+| 8 | Dark mode | Toggle dark mode, buka dropdown | Dropdown konsisten dengan tema aktif |
+
+## Notes
+
+- Gunakan `DropdownMenu`, `DropdownMenuTrigger`, `DropdownMenuContent`, `DropdownMenuItem`, `DropdownMenuSeparator`, `DropdownMenuLabel` dari shadcn.
+- Untuk nama user: ambil dari `useAuthStore((state) => state.user?.name)`.
+- Jika `user.name` belum tersinkron setelah update profil (Issue #19), pastikan Issue #19 sudah menyelesaikan sync ke store terlebih dahulu agar ini langsung berfungsi.

--- a/src/features/auth/auth.hook.ts
+++ b/src/features/auth/auth.hook.ts
@@ -36,7 +36,7 @@ export const useLogin = () => {
 
     const from = fromLocation
         ? `${fromLocation.pathname}${fromLocation.search}${fromLocation.hash}`
-        : "/";
+        : "/dashboard";
 
     return useMutation({
 

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
 import { useLogin } from "../auth.hook";
 import { LoginPayloadSchema, type LoginPayload } from "../auth.schema";
 import { useForm } from "react-hook-form";
@@ -6,13 +7,16 @@ import { InputField } from "@/components/form/InputField";
 import { InputPasswordField } from "@/components/form/InputPaswordField";
 import { ButtonField } from "@/components/form/ButtonField";
 import { FieldGroup, FieldSet } from "@/components/ui/field";
+import { useAppStore } from "@/stores/app.store";
 
 export const LoginForm = () => {
 
     const { mutate, isPending } = useLogin();
+    const isOpenToggleForm = useAppStore((s) => s.isOpenToggleForm);
 
     const {
         register,
+        setFocus,
         handleSubmit,
         formState: { errors },
     } = useForm<LoginPayload>({
@@ -22,6 +26,12 @@ export const LoginForm = () => {
             password: "",
         }
     })
+
+    useEffect(() => {
+        if (!isOpenToggleForm) return;
+        const id = requestAnimationFrame(() => setFocus("username"));
+        return () => cancelAnimationFrame(id);
+    }, [isOpenToggleForm, setFocus]);
 
     const onSubmit = (values: LoginPayload) => mutate(values);
 

--- a/src/features/auth/components/RegisterForm.tsx
+++ b/src/features/auth/components/RegisterForm.tsx
@@ -1,4 +1,5 @@
 import { FieldGroup, FieldSet } from "@/components/ui/field";
+import { useEffect } from "react";
 import { useRegister } from "../auth.hook";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -6,13 +7,16 @@ import { RegisterSchema, type RegisterFormValues } from "../auth.schema";
 import { InputField } from "@/components/form/InputField";
 import { InputPasswordField } from "@/components/form/InputPaswordField";
 import { ButtonField } from "@/components/form/ButtonField";
+import { useAppStore } from "@/stores/app.store";
 
 export const RegisterForm = () => {
 
     const { mutate, isPending } = useRegister();
+    const isOpenToggleForm = useAppStore((s) => s.isOpenToggleForm);
 
     const {
         register,
+        setFocus,
         handleSubmit,
         formState: { errors },
     } = useForm<RegisterFormValues>({
@@ -24,6 +28,12 @@ export const RegisterForm = () => {
             confirmPassword: "",
         }
     });
+
+    useEffect(() => {
+        if (!isOpenToggleForm) return;
+        const id = requestAnimationFrame(() => setFocus("username"));
+        return () => cancelAnimationFrame(id);
+    }, [isOpenToggleForm, setFocus]);
 
     const onSubmit = (values: RegisterFormValues) => {
 

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,0 +1,9 @@
+const ProfilePage = () => {
+    return (
+        <div>
+            <h1>ProfilePage</h1>
+        </div>
+    );
+};
+
+export default ProfilePage;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,12 +1,13 @@
 import { AuthLayout } from "@/layouts/AuthLayout";
 import { MainLayout } from "@/layouts/MainLayout";
-import { createBrowserRouter } from "react-router";
+import { createBrowserRouter, Navigate } from "react-router";
 
 import RegisterPage from "@/pages/RegisterPage";
 import ContactPage from "@/pages/ContactPage";
 import LoginPage from "@/pages/LoginPage";
 import { AuthGuard } from "@/features/auth/guards/AuthGuard";
 import { GuestGuard } from "@/features/auth/guards/GuestGuard";
+import ProfilePage from "@/pages/ProfilePage";
 
 export const router = createBrowserRouter([
     {
@@ -32,14 +33,22 @@ export const router = createBrowserRouter([
         Component: AuthGuard,
         children: [
             {
+                path: "/",
+                element: <Navigate to="/dashboard" replace />,
+            },
+            {
                 Component: MainLayout,
                 children: [
                     {
-                        path: "/",
+                        path: "dashboard",
                         Component: ContactPage,
-                    }
-                ]
-            }
-        ]
+                    },
+                    {
+                        path: "profile",
+                        Component: ProfilePage,
+                    },
+                ],
+            },
+        ],
     },
 ])


### PR DESCRIPTION
- redirect  to  under AuthGuard; move contacts to
- add placeholder  route and ProfilePage under MainLayout
- default post-login navigation to  when no  state in useLogin
- focus username field when auth sheet opens on LoginForm and RegisterForm